### PR TITLE
Lock to scale changed to set to scale

### DIFF
--- a/Roche-Engine/Components/EntityEditor.cpp
+++ b/Roche-Engine/Components/EntityEditor.cpp
@@ -728,10 +728,7 @@ void EntityEditor::SetColliderShape()
 void EntityEditor::SetColliderSize()
 {
 #if _DEBUG
-	ImGui::Checkbox("Lock To Scale", &m_bLockToScale);
-
-	if (m_bLockToScale)
-	{
+	if(ImGui::Button("Set to Scale")) {
 		m_vEntityDataCopy[m_iIdentifier].colliderRadius[0] = m_vEntityDataCopy[m_iIdentifier].scale[0];
 		m_vEntityDataCopy[m_iIdentifier].colliderRadius[1] = m_vEntityDataCopy[m_iIdentifier].scale[1];
 	}

--- a/Roche-Engine/Components/EntityEditor.h
+++ b/Roche-Engine/Components/EntityEditor.h
@@ -105,7 +105,6 @@ private:
 
 	bool m_bIsUpdated;
 	bool m_bLockPosition;
-	bool m_bLockToScale;
 
 	float m_fPushItemWidthFull = 210.0f;
 	float m_fPushItemWidthHalf = 100.0f;


### PR DESCRIPTION
**Describe your changes**
Now it's a button you can press to set collider size to match the size of a sprite

**Screenshots**
Not gonna bother since its such a small change and needs to be quickly pushed

**Additional context**
It was messing with collisions
